### PR TITLE
Exception handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,6 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.camel</groupId>
-			<artifactId>camel-spring-redis</artifactId>
-			<version>2.18.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.camel</groupId>
 			<artifactId>camel-aws</artifactId>
 			<version>2.18.2</version>
 		</dependency>
@@ -59,9 +54,17 @@
 			<artifactId>spring-security-oauth2</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.retry</groupId>
+			<artifactId>spring-retry</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.avro</groupId>
 			<artifactId>avro</artifactId>
 			<version>1.8.1</version>
+		</dependency>
+		<dependency>
+			<groupId>redis.clients</groupId>
+			<artifactId>jedis</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/nypl/harvester/sierra/api/utils/OAuth2Client.java
+++ b/src/main/java/org/nypl/harvester/sierra/api/utils/OAuth2Client.java
@@ -34,8 +34,8 @@ public class OAuth2Client {
   }
 
   public OAuth2RestTemplate getOAuth2RestTemplate() {
-    OAuth2RestTemplate oAuth2RestTemplate = new OAuth2RestTemplate(
-        getClientCredentialsResourceDetails());
+    OAuth2RestTemplate oAuth2RestTemplate =
+        new OAuth2RestTemplate(getClientCredentialsResourceDetails());
 
     return oAuth2RestTemplate;
   }

--- a/src/main/java/org/nypl/harvester/sierra/api/utils/StreamDataTranslator.java
+++ b/src/main/java/org/nypl/harvester/sierra/api/utils/StreamDataTranslator.java
@@ -6,15 +6,18 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class StreamDataTranslator {
-  public static StreamDataModel translate(StreamDataModel streamData, Object object) throws SierraHarvesterException {
+  public static StreamDataModel translate(StreamDataModel streamData, Object object)
+      throws SierraHarvesterException {
     try {
-      StreamDataModel newStreamData = (StreamDataModel) Class.forName(streamData.getClass().getName()).newInstance();
+      StreamDataModel newStreamData =
+          (StreamDataModel) Class.forName(streamData.getClass().getName()).newInstance();
 
       newStreamData.translateToStreamData(object);
 
       return newStreamData;
     } catch (Exception exception) {
-      throw new SierraHarvesterException("Unable to translate object to stream data: " + exception.getMessage());
+      throw new SierraHarvesterException(
+          "Unable to translate object to stream data: " + exception.getMessage());
     }
   }
 }

--- a/src/main/java/org/nypl/harvester/sierra/exception/SierraHarvesterException.java
+++ b/src/main/java/org/nypl/harvester/sierra/exception/SierraHarvesterException.java
@@ -3,13 +3,13 @@ package org.nypl.harvester.sierra.exception;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SierraHarvesterException extends Exception{
-	
-	private static final long serialVersionUID = -3886346817890754286L;
-	
-	private static Logger logger = LoggerFactory.getLogger(SierraHarvesterException.class);
-	
-	public SierraHarvesterException(String message){
-		logger.error("SierraHarvesterException occurred - " + message);
-	}
+public class SierraHarvesterException extends Exception {
+
+  private static final long serialVersionUID = -3886346817890754286L;
+
+  private static Logger logger = LoggerFactory.getLogger(SierraHarvesterException.class);
+
+  public SierraHarvesterException(String message) {
+    logger.error("SierraHarvesterException occurred - " + message);
+  }
 }

--- a/src/main/java/org/nypl/harvester/sierra/processor/CacheItemIdMonitor.java
+++ b/src/main/java/org/nypl/harvester/sierra/processor/CacheItemIdMonitor.java
@@ -24,10 +24,10 @@ public class CacheItemIdMonitor implements Processor {
   @Override
   public void process(Exchange exchange) throws SierraHarvesterException {
     try {
-      String value = retryTemplate.execute(new RetryCallback<String, Throwable>() {
+      String value = retryTemplate.execute(new RetryCallback<String, SierraHarvesterException>() {
 
         @Override
-        public String doWithRetry(RetryContext retryContext) throws Throwable {
+        public String doWithRetry(RetryContext retryContext) throws SierraHarvesterException {
           return getCacheStoreValue();
         }
 
@@ -37,9 +37,6 @@ public class CacheItemIdMonitor implements Processor {
     } catch (Exception exception) {
       logger.error("Hit an issue with checking redis - ", exception);
       throw new SierraHarvesterException(exception.getMessage());
-    } catch (Throwable e) {
-      logger.error("Hit an issue with checking redis - ", e);
-      throw new SierraHarvesterException(e.getMessage());
     }
   }
 

--- a/src/main/java/org/nypl/harvester/sierra/processor/CacheItemIdMonitor.java
+++ b/src/main/java/org/nypl/harvester/sierra/processor/CacheItemIdMonitor.java
@@ -2,45 +2,59 @@ package org.nypl.harvester.sierra.processor;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.apache.camel.ProducerTemplate;
 import org.nypl.harvester.sierra.exception.SierraHarvesterException;
 import org.nypl.harvester.sierra.utils.HarvesterConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.support.RetryTemplate;
+
+import redis.clients.jedis.Jedis;
 
 public class CacheItemIdMonitor implements Processor {
 
   private static Logger logger = LoggerFactory.getLogger(CacheItemIdMonitor.class);
-  private ProducerTemplate template;
+  private RetryTemplate retryTemplate;
 
-  public CacheItemIdMonitor(ProducerTemplate template) {
-    this.template = template;
+  public CacheItemIdMonitor(RetryTemplate retryTemplate) {
+    this.retryTemplate = retryTemplate;
   }
 
   @Override
   public void process(Exchange exchange) throws SierraHarvesterException {
     try {
-      Exchange templateResultExchange = template.send(
-          "spring-redis://" +
-              System.getenv("redisHost") + ":" + System.getenv("redisPort") + "?command=GET"
-              + "&redisTemplate=#redisTemplate",
-          new Processor() {
-            @Override
-            public void process(Exchange redisMessageExchange) throws Exception {
-              redisMessageExchange.getIn().setHeader("CamelRedis.Key",
-                  HarvesterConstants.REDIS_KEY_LAST_UPDATED_TIME);
-            }
-          });
+      String value = retryTemplate.execute(new RetryCallback<String, Throwable>() {
 
-      String value = templateResultExchange.getIn().getBody(String.class);
+        @Override
+        public String doWithRetry(RetryContext retryContext) throws Throwable {
+          return getCacheStoreValue();
+        }
+
+      });
       exchange.getIn().setBody(value);
-
       logger.debug("Cached last updated date" + value);
     } catch (Exception exception) {
       logger.error("Hit an issue with checking redis - ", exception);
-
       throw new SierraHarvesterException(exception.getMessage());
+    } catch (Throwable e) {
+      logger.error("Hit an issue with checking redis - ", e);
+      throw new SierraHarvesterException(e.getMessage());
     }
+  }
+  
+  public String getCacheStoreValue() throws SierraHarvesterException{
+    Jedis jedis = null;
+    try{
+      jedis = new Jedis(System.getenv("redisHost"), Integer.parseInt(System.getenv("redisPort")));
+      return jedis.get(HarvesterConstants.REDIS_KEY_LAST_UPDATED_TIME);
+    }catch(Exception e){
+      logger.error("Error occurred while getting last updated time from redis server - ", e);
+      throw new SierraHarvesterException("Error occurred while getting last updated time from redis server");
+    }finally{
+      jedis.close();
+    }
+    
   }
 
 }

--- a/src/main/java/org/nypl/harvester/sierra/processor/CacheItemIdMonitor.java
+++ b/src/main/java/org/nypl/harvester/sierra/processor/CacheItemIdMonitor.java
@@ -42,19 +42,20 @@ public class CacheItemIdMonitor implements Processor {
       throw new SierraHarvesterException(e.getMessage());
     }
   }
-  
-  public String getCacheStoreValue() throws SierraHarvesterException{
+
+  public String getCacheStoreValue() throws SierraHarvesterException {
     Jedis jedis = null;
-    try{
+    try {
       jedis = new Jedis(System.getenv("redisHost"), Integer.parseInt(System.getenv("redisPort")));
       return jedis.get(HarvesterConstants.REDIS_KEY_LAST_UPDATED_TIME);
-    }catch(Exception e){
+    } catch (Exception e) {
       logger.error("Error occurred while getting last updated time from redis server - ", e);
-      throw new SierraHarvesterException("Error occurred while getting last updated time from redis server");
-    }finally{
+      throw new SierraHarvesterException(
+          "Error occurred while getting last updated time from redis server");
+    } finally {
       jedis.close();
     }
-    
+
   }
 
 }

--- a/src/main/java/org/nypl/harvester/sierra/processor/CacheLastUpdatedTimeUpdater.java
+++ b/src/main/java/org/nypl/harvester/sierra/processor/CacheLastUpdatedTimeUpdater.java
@@ -27,13 +27,14 @@ public class CacheLastUpdatedTimeUpdater implements Processor {
 
   private void updateCache(String timeToUpdateInCache) throws SierraHarvesterException {
     Jedis jedis = null;
-    try{
+    try {
       jedis = new Jedis(System.getenv("redisHost"), Integer.parseInt(System.getenv("redisPort")));
       jedis.set(HarvesterConstants.REDIS_KEY_LAST_UPDATED_TIME, timeToUpdateInCache);
-    }catch(Exception e){
+    } catch (Exception e) {
       logger.error("Error occurred while getting last updated time from redis server - ", e);
-      throw new SierraHarvesterException("Error occurred while getting last updated time from redis server");
-    }finally{
+      throw new SierraHarvesterException(
+          "Error occurred while getting last updated time from redis server");
+    } finally {
       jedis.close();
     }
   }

--- a/src/main/java/org/nypl/harvester/sierra/processor/CacheLastUpdatedTimeUpdater.java
+++ b/src/main/java/org/nypl/harvester/sierra/processor/CacheLastUpdatedTimeUpdater.java
@@ -25,19 +25,24 @@ public class CacheLastUpdatedTimeUpdater implements Processor {
 
   @Override
   public void process(Exchange exchange) throws SierraHarvesterException {
-    Map<String, Object> exchangeContents = exchange.getIn().getBody(Map.class);
+    try {
+      Map<String, Object> exchangeContents = exchange.getIn().getBody(Map.class);
 
-    String timeToUpdateInCache =
-        (String) exchangeContents.get(HarvesterConstants.REDIS_KEY_LAST_UPDATED_TIME);
-    retryTemplate.execute(new RetryCallback<Boolean, SierraHarvesterException>() {
+      String timeToUpdateInCache =
+          (String) exchangeContents.get(HarvesterConstants.REDIS_KEY_LAST_UPDATED_TIME);
+      retryTemplate.execute(new RetryCallback<Boolean, SierraHarvesterException>() {
 
-      @Override
-      public Boolean doWithRetry(RetryContext context) throws SierraHarvesterException {
-        return updateCache(timeToUpdateInCache);
-      }
+        @Override
+        public Boolean doWithRetry(RetryContext context) throws SierraHarvesterException {
+          return updateCache(timeToUpdateInCache);
+        }
 
-    });
-
+      });
+    } catch (Exception e) {
+      logger.error("Error occurred while updating redis with the last updated time - ", e);
+      throw new SierraHarvesterException(
+          "Error occurred while updating redis with the last updated time - " + e.getMessage());
+    }
   }
 
   private Boolean updateCache(String timeToUpdateInCache) throws SierraHarvesterException {

--- a/src/main/java/org/nypl/harvester/sierra/processor/CacheLastUpdatedTimeUpdater.java
+++ b/src/main/java/org/nypl/harvester/sierra/processor/CacheLastUpdatedTimeUpdater.java
@@ -8,12 +8,21 @@ import org.nypl.harvester.sierra.exception.SierraHarvesterException;
 import org.nypl.harvester.sierra.utils.HarvesterConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.support.RetryTemplate;
 
 import redis.clients.jedis.Jedis;
 
 public class CacheLastUpdatedTimeUpdater implements Processor {
+  
+  private RetryTemplate retryTemplate;
 
   private static Logger logger = LoggerFactory.getLogger(CacheLastUpdatedTimeUpdater.class);
+  
+  public CacheLastUpdatedTimeUpdater(RetryTemplate retryTemplate) {
+    this.retryTemplate = retryTemplate;
+  }
 
   @Override
   public void process(Exchange exchange) throws SierraHarvesterException {
@@ -21,15 +30,23 @@ public class CacheLastUpdatedTimeUpdater implements Processor {
 
     String timeToUpdateInCache =
         (String) exchangeContents.get(HarvesterConstants.REDIS_KEY_LAST_UPDATED_TIME);
+    retryTemplate.execute(new RetryCallback<Boolean, SierraHarvesterException>() {
 
-    updateCache(timeToUpdateInCache);
+      @Override
+      public Boolean doWithRetry(RetryContext context) throws SierraHarvesterException {
+        return updateCache(timeToUpdateInCache);
+      }
+      
+    });
+    
   }
 
-  private void updateCache(String timeToUpdateInCache) throws SierraHarvesterException {
+  private Boolean updateCache(String timeToUpdateInCache) throws SierraHarvesterException {
     Jedis jedis = null;
     try {
       jedis = new Jedis(System.getenv("redisHost"), Integer.parseInt(System.getenv("redisPort")));
       jedis.set(HarvesterConstants.REDIS_KEY_LAST_UPDATED_TIME, timeToUpdateInCache);
+      return true;
     } catch (Exception e) {
       logger.error("Error occurred while getting last updated time from redis server - ", e);
       throw new SierraHarvesterException(

--- a/src/main/java/org/nypl/harvester/sierra/processor/CacheLastUpdatedTimeUpdater.java
+++ b/src/main/java/org/nypl/harvester/sierra/processor/CacheLastUpdatedTimeUpdater.java
@@ -3,7 +3,6 @@ package org.nypl.harvester.sierra.processor;
 import java.util.Map;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
-import org.apache.camel.ProducerTemplate;
 import org.nypl.harvester.sierra.exception.SierraHarvesterException;
 import org.nypl.harvester.sierra.utils.HarvesterConstants;
 import org.slf4j.Logger;
@@ -15,11 +14,11 @@ import org.springframework.retry.support.RetryTemplate;
 import redis.clients.jedis.Jedis;
 
 public class CacheLastUpdatedTimeUpdater implements Processor {
-  
+
   private RetryTemplate retryTemplate;
 
   private static Logger logger = LoggerFactory.getLogger(CacheLastUpdatedTimeUpdater.class);
-  
+
   public CacheLastUpdatedTimeUpdater(RetryTemplate retryTemplate) {
     this.retryTemplate = retryTemplate;
   }
@@ -36,9 +35,9 @@ public class CacheLastUpdatedTimeUpdater implements Processor {
       public Boolean doWithRetry(RetryContext context) throws SierraHarvesterException {
         return updateCache(timeToUpdateInCache);
       }
-      
+
     });
-    
+
   }
 
   private Boolean updateCache(String timeToUpdateInCache) throws SierraHarvesterException {

--- a/src/main/java/org/nypl/harvester/sierra/processor/CacheLastUpdatedTimeUpdater.java
+++ b/src/main/java/org/nypl/harvester/sierra/processor/CacheLastUpdatedTimeUpdater.java
@@ -6,41 +6,36 @@ import org.apache.camel.Processor;
 import org.apache.camel.ProducerTemplate;
 import org.nypl.harvester.sierra.exception.SierraHarvesterException;
 import org.nypl.harvester.sierra.utils.HarvesterConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import redis.clients.jedis.Jedis;
 
 public class CacheLastUpdatedTimeUpdater implements Processor {
 
-  private ProducerTemplate template;
-
-  public CacheLastUpdatedTimeUpdater(ProducerTemplate template) {
-    this.template = template;
-  }
+  private static Logger logger = LoggerFactory.getLogger(CacheLastUpdatedTimeUpdater.class);
 
   @Override
   public void process(Exchange exchange) throws SierraHarvesterException {
     Map<String, Object> exchangeContents = exchange.getIn().getBody(Map.class);
 
-    String timeToUpdateInCache = (String) exchangeContents.get(
-        HarvesterConstants.REDIS_KEY_LAST_UPDATED_TIME);
+    String timeToUpdateInCache =
+        (String) exchangeContents.get(HarvesterConstants.REDIS_KEY_LAST_UPDATED_TIME);
 
     updateCache(timeToUpdateInCache);
   }
 
-  private void updateCache(String timeToUpdateInCache) {
-    Exchange templateResultExchange = template.send(
-        "spring-redis://" +
-            System.getenv("redisHost") + ":" + System.getenv("redisPort") + "?command=SET" +
-            "&redisTemplate=#redisTemplate",
-        new Processor() {
-          @Override
-          public void process(Exchange redisMessageExchange) throws Exception {
-
-            redisMessageExchange.getIn().setHeader("CamelRedis.Key",
-                HarvesterConstants.REDIS_KEY_LAST_UPDATED_TIME);
-            redisMessageExchange.getIn().setHeader("CamelRedis.Value",
-                timeToUpdateInCache);
-          }
-        }
-        );
+  private void updateCache(String timeToUpdateInCache) throws SierraHarvesterException {
+    Jedis jedis = null;
+    try{
+      jedis = new Jedis(System.getenv("redisHost"), Integer.parseInt(System.getenv("redisPort")));
+      jedis.set(HarvesterConstants.REDIS_KEY_LAST_UPDATED_TIME, timeToUpdateInCache);
+    }catch(Exception e){
+      logger.error("Error occurred while getting last updated time from redis server - ", e);
+      throw new SierraHarvesterException("Error occurred while getting last updated time from redis server");
+    }finally{
+      jedis.close();
+    }
   }
 
 }

--- a/src/main/java/org/nypl/harvester/sierra/processor/ItemIdUpdateHarvester.java
+++ b/src/main/java/org/nypl/harvester/sierra/processor/ItemIdUpdateHarvester.java
@@ -37,10 +37,11 @@ public class ItemIdUpdateHarvester implements Processor {
   private String token;
 
   private String newUpdatedTime;
-  
+
   private RetryTemplate retryTemplate;
 
-  public ItemIdUpdateHarvester(String token, ProducerTemplate producerTemplate, RetryTemplate retryTemplate) {
+  public ItemIdUpdateHarvester(String token, ProducerTemplate producerTemplate,
+      RetryTemplate retryTemplate) {
     this.token = token;
     this.template = producerTemplate;
     this.retryTemplate = retryTemplate;
@@ -209,26 +210,29 @@ public class ItemIdUpdateHarvester implements Processor {
 
     logger.info("Calling api - " + itemApiToCall);
 
-    Exchange templateResultExchange = retryTemplate.execute(new RetryCallback<Exchange, SierraHarvesterException>() {
+    Exchange templateResultExchange =
+        retryTemplate.execute(new RetryCallback<Exchange, SierraHarvesterException>() {
 
-      @Override
-      public Exchange doWithRetry(RetryContext context) throws SierraHarvesterException {
-        try{
-          return template.request(itemApiToCall, new Processor() {
-            @Override
-            public void process(Exchange httpHeaderExchange) throws Exception {
-              httpHeaderExchange.getIn().setHeader(Exchange.HTTP_METHOD, HttpMethod.GET);
-              httpHeaderExchange.getIn().setHeader(HarvesterConstants.SIERRA_API_HEADER_KEY_AUTHORIZATION,
-                  HarvesterConstants.SIERRA_API_HEADER_AUTHORIZATION_VAL_BEARER + " " + token);
+          @Override
+          public Exchange doWithRetry(RetryContext context) throws SierraHarvesterException {
+            try {
+              return template.request(itemApiToCall, new Processor() {
+                @Override
+                public void process(Exchange httpHeaderExchange) throws Exception {
+                  httpHeaderExchange.getIn().setHeader(Exchange.HTTP_METHOD, HttpMethod.GET);
+                  httpHeaderExchange.getIn().setHeader(
+                      HarvesterConstants.SIERRA_API_HEADER_KEY_AUTHORIZATION,
+                      HarvesterConstants.SIERRA_API_HEADER_AUTHORIZATION_VAL_BEARER + " " + token);
+                }
+              });
+            } catch (Exception e) {
+              logger.error("Error occurred while calling sierra api - ", e);
+              throw new SierraHarvesterException(
+                  "Error occurred while calling sierra item api - " + e.getMessage());
             }
-          });
-        }catch(Exception e){
-          logger.error("Error occurred while calling sierra api - ", e);
-          throw new SierraHarvesterException("Error occurred while calling sierra item api - " + e.getMessage());
-        }
-      }
-      
-    });
+          }
+
+        });
 
     return templateResultExchange;
   }

--- a/src/main/java/org/nypl/harvester/sierra/processor/ItemIdUpdateHarvester.java
+++ b/src/main/java/org/nypl/harvester/sierra/processor/ItemIdUpdateHarvester.java
@@ -11,6 +11,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TimeZone;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
@@ -87,15 +88,19 @@ public class ItemIdUpdateHarvester implements Processor {
         Map<String, Object> apiResponse = new ObjectMapper().readValue(
             (String) response.get(HarvesterConstants.SIERRA_API_RESPONSE_BODY), Map.class);
 
-        total = (Integer) apiResponse.get(HarvesterConstants.SIERRA_API_RESPONSE_TOTAL);
+        Optional<Integer> optionalTotal = Optional
+            .ofNullable((Integer) apiResponse.get(HarvesterConstants.SIERRA_API_RESPONSE_TOTAL));
 
-        items = addItemsFromAPIResponse(apiResponse, items);
+        if (optionalTotal.isPresent()) {
+          total = (Integer) apiResponse.get(HarvesterConstants.SIERRA_API_RESPONSE_TOTAL);
+          items = addItemsFromAPIResponse(apiResponse, items);
 
-        if (total < limit) {
-          return items;
-        } else {
-          return getAllItemsForTimeRange(response, total, items, limit, offset, startTime,
-              newUpdatedTime);
+          if (total < limit) {
+            return items;
+          } else {
+            return getAllItemsForTimeRange(response, total, items, limit, offset, startTime,
+                newUpdatedTime);
+          }
         }
       }
 

--- a/src/main/java/org/nypl/harvester/sierra/processor/ItemIdUpdateHarvester.java
+++ b/src/main/java/org/nypl/harvester/sierra/processor/ItemIdUpdateHarvester.java
@@ -36,7 +36,7 @@ public class ItemIdUpdateHarvester implements Processor {
   private String newUpdatedTime;
 
   public ItemIdUpdateHarvester(String token, ProducerTemplate producerTemplate) {
-		this.token = token;
+    this.token = token;
     this.template = producerTemplate;
   }
 
@@ -48,15 +48,10 @@ public class ItemIdUpdateHarvester implements Processor {
 
       Map<String, Object> exchangeContents = new HashMap<>();
 
-      exchangeContents.put(
-          HarvesterConstants.APP_ITEMS_LIST,
-          iterateToGetItemIds(lastUpdatedDateTime)
-      );
+      exchangeContents.put(HarvesterConstants.APP_ITEMS_LIST,
+          iterateToGetItemIds(lastUpdatedDateTime));
 
-      exchangeContents.put(
-          HarvesterConstants.REDIS_KEY_LAST_UPDATED_TIME,
-          newUpdatedTime
-      );
+      exchangeContents.put(HarvesterConstants.REDIS_KEY_LAST_UPDATED_TIME, newUpdatedTime);
 
       exchange.getIn().setBody(exchangeContents);
     } catch (NullPointerException npe) {
@@ -76,22 +71,14 @@ public class ItemIdUpdateHarvester implements Processor {
 
       newUpdatedTime = getCurrentTimeInZuluTimeFormat();
 
-      Map<String, Object> response = getResultsFromSierra(
-          startTime,
-          newUpdatedTime,
-          offset,
-          limit
-      );
+      Map<String, Object> response = getResultsFromSierra(startTime, newUpdatedTime, offset, limit);
 
-      Integer responseCode = (Integer) response.get(
-          HarvesterConstants.SIERRA_API_RESPONSE_HTTP_CODE
-      );
+      Integer responseCode =
+          (Integer) response.get(HarvesterConstants.SIERRA_API_RESPONSE_HTTP_CODE);
 
       if (responseCode == 200) {
         Map<String, Object> apiResponse = new ObjectMapper().readValue(
-            (String) response.get(HarvesterConstants.SIERRA_API_RESPONSE_BODY),
-            Map.class
-        );
+            (String) response.get(HarvesterConstants.SIERRA_API_RESPONSE_BODY), Map.class);
 
         total = (Integer) apiResponse.get(HarvesterConstants.SIERRA_API_RESPONSE_TOTAL);
 
@@ -100,45 +87,28 @@ public class ItemIdUpdateHarvester implements Processor {
         if (total < limit) {
           return items;
         } else {
-          return getAllItemsForTimeRange(
-              response,
-              total,
-              items,
-              limit,
-              offset,
-              startTime,
-              newUpdatedTime
-          );
+          return getAllItemsForTimeRange(response, total, items, limit, offset, startTime,
+              newUpdatedTime);
         }
       }
 
       return items;
     } catch (JsonParseException jsonParseException) {
-      logger.error(
-          "Hit a json parse exception while parsing json response from items " + "api - ",
-          jsonParseException
-      );
+      logger.error("Hit a json parse exception while parsing json response from items " + "api - ",
+          jsonParseException);
 
-      throw new SierraHarvesterException(
-          "JsonParseException while parsing items " + "response - " +
-              jsonParseException.getMessage()
-      );
+      throw new SierraHarvesterException("JsonParseException while parsing items " + "response - "
+          + jsonParseException.getMessage());
     } catch (JsonMappingException jsonMappingException) {
-      logger.error(
-          "Hit a json mapping exception for items api response ",
-          jsonMappingException
-      );
+      logger.error("Hit a json mapping exception for items api response ", jsonMappingException);
 
-      throw new SierraHarvesterException(
-          "JsonMappingException while for items api response " + "- " +
-              jsonMappingException.getMessage()
-      );
+      throw new SierraHarvesterException("JsonMappingException while for items api response " + "- "
+          + jsonMappingException.getMessage());
     } catch (IOException ioe) {
       logger.error("Hit an IOException - ", ioe);
 
       throw new SierraHarvesterException(
-          "IOException while for items api response " + "- " + ioe.getMessage()
-      );
+          "IOException while for items api response " + "- " + ioe.getMessage());
     }
   }
 
@@ -149,67 +119,50 @@ public class ItemIdUpdateHarvester implements Processor {
       while (total == limit) {
         offset += limit;
 
-        response = getResultsFromSierra(
-            startTime,
-            endTime,
-            offset,
-            limit
-        );
+        response = getResultsFromSierra(startTime, endTime, offset, limit);
 
-        Integer responseCode = (Integer) response.get(
-            HarvesterConstants.SIERRA_API_RESPONSE_HTTP_CODE
-        );
+        Integer responseCode =
+            (Integer) response.get(HarvesterConstants.SIERRA_API_RESPONSE_HTTP_CODE);
 
-				if (responseCode == 200) {
-					Map<String, Object> apiResponse = new ObjectMapper().readValue(
-							(String) response.get(HarvesterConstants.SIERRA_API_RESPONSE_BODY),
-              Map.class
-          );
+        if (responseCode == 200) {
+          Map<String, Object> apiResponse = new ObjectMapper().readValue(
+              (String) response.get(HarvesterConstants.SIERRA_API_RESPONSE_BODY), Map.class);
 
-					total = (Integer) apiResponse.get(HarvesterConstants.SIERRA_API_RESPONSE_TOTAL);
+          total = (Integer) apiResponse.get(HarvesterConstants.SIERRA_API_RESPONSE_TOTAL);
 
-					items = addItemsFromAPIResponse(apiResponse, items);
+          items = addItemsFromAPIResponse(apiResponse, items);
 
-					if (total < limit) {
-						return items;
-					}
-				} else {
-					return items;
-				}
+          if (total < limit) {
+            return items;
+          }
+        } else {
+          return items;
+        }
       }
 
       return items;
     } catch (JsonParseException jsonParseException) {
-      logger.error(
-          "Hit a json parse exception while parsing json response from items " + "api - ",
-          jsonParseException
-      );
+      logger.error("Hit a json parse exception while parsing json response from items " + "api - ",
+          jsonParseException);
 
-      throw new SierraHarvesterException(
-          "JsonParseException while parsing items " + "response - " + jsonParseException.getMessage()
-      );
+      throw new SierraHarvesterException("JsonParseException while parsing items " + "response - "
+          + jsonParseException.getMessage());
     } catch (JsonMappingException jsonMappingException) {
-      logger.error(
-          "Hit a json mapping exception for items api response ",
-          jsonMappingException
-      );
+      logger.error("Hit a json mapping exception for items api response ", jsonMappingException);
 
-      throw new SierraHarvesterException(
-          "JsonMappingException while for items api response " + "- " + jsonMappingException.getMessage()
-      );
+      throw new SierraHarvesterException("JsonMappingException while for items api response " + "- "
+          + jsonMappingException.getMessage());
     } catch (IOException ioe) {
       logger.error("Hit an IOException - ", ioe);
 
       throw new SierraHarvesterException(
-          "IOException while for items api response " + "- " + ioe.getMessage()
-      );
+          "IOException while for items api response " + "- " + ioe.getMessage());
     }
   }
 
   private List<Item> addItemsFromAPIResponse(Map<String, Object> apiResponse, List<Item> items) {
-    List<Map<String, Object>> entries = (List<Map<String, Object>>) apiResponse.get(
-        HarvesterConstants.SIERRA_API_RESPONSE_ENTRIES
-    );
+    List<Map<String, Object>> entries =
+        (List<Map<String, Object>>) apiResponse.get(HarvesterConstants.SIERRA_API_RESPONSE_ENTRIES);
 
     for (Map<String, Object> entry : entries) {
       Item item = new Item();
@@ -220,8 +173,8 @@ public class ItemIdUpdateHarvester implements Processor {
     return items;
   }
 
-  private Map<String, Object> getResultsFromSierra(String startDdate, String endDate,
-      int offset, int limit) {
+  private Map<String, Object> getResultsFromSierra(String startDdate, String endDate, int offset,
+      int limit) {
     Exchange apiResponse = getExchangeWithAPIResponse(startDdate, endDate, offset, limit);
 
     Map<String, Object> response = getResponseFromExchange(apiResponse);
@@ -239,25 +192,25 @@ public class ItemIdUpdateHarvester implements Processor {
     return response;
   }
 
-  private Exchange getExchangeWithAPIResponse(String startDdate, String endDate,
-      int offset, int limit) {
-    String itemApiToCall = System.getenv("sierraItemApi") + "?" +
-        HarvesterConstants.SIERRA_API_UPDATED_DATE + "=[" + startDdate + "," + endDate + "]&" +
-        HarvesterConstants.SIERRA_API_OFFSET + "=" + offset + "&" +
-        HarvesterConstants.SIERRA_API_LIMIT + "=" + limit + "&" +
-        HarvesterConstants.SIERRA_API_FIELDS_PARAMETER + "=" + HarvesterConstants.SIERRA_API_FIELDS_VALUE;
+  private Exchange getExchangeWithAPIResponse(String startDdate, String endDate, int offset,
+      int limit) {
+    String itemApiToCall =
+        System.getenv("sierraItemApi") + "?" + HarvesterConstants.SIERRA_API_UPDATED_DATE + "=["
+            + startDdate + "," + endDate + "]&" + HarvesterConstants.SIERRA_API_OFFSET + "="
+            + offset + "&" + HarvesterConstants.SIERRA_API_LIMIT + "=" + limit + "&"
+            + HarvesterConstants.SIERRA_API_FIELDS_PARAMETER + "="
+            + HarvesterConstants.SIERRA_API_FIELDS_VALUE;
 
     logger.info("Calling api - " + itemApiToCall);
 
-    Exchange templateResultExchange = template.send(itemApiToCall,
-        new Processor() {
-          @Override
-          public void process(Exchange httpHeaderExchange) throws Exception {
-            httpHeaderExchange.getIn().setHeader(Exchange.HTTP_METHOD, HttpMethod.GET);
-            httpHeaderExchange.getIn().setHeader("Authorization", "bearer " + token);
-          }
-        }
-        );
+    Exchange templateResultExchange = template.send(itemApiToCall, new Processor() {
+      @Override
+      public void process(Exchange httpHeaderExchange) throws Exception {
+        httpHeaderExchange.getIn().setHeader(Exchange.HTTP_METHOD, HttpMethod.GET);
+        httpHeaderExchange.getIn().setHeader(HarvesterConstants.SIERRA_API_HEADER_KEY_AUTHORIZATION,
+            HarvesterConstants.SIERRA_API_HEADER_AUTHORIZATION_VAL_BEARER + " " + token);
+      }
+    });
 
     return templateResultExchange;
   }
@@ -265,9 +218,8 @@ public class ItemIdUpdateHarvester implements Processor {
   private Map<String, Object> getResponseFromExchange(Exchange exchange) {
     Message out = exchange.getOut();
 
-    HttpOperationFailedException httpOperationFailedException = exchange.getException(
-        HttpOperationFailedException.class
-    );
+    HttpOperationFailedException httpOperationFailedException =
+        exchange.getException(HttpOperationFailedException.class);
 
     Integer responseCode = null;
     String apiResponse = null;

--- a/src/main/java/org/nypl/harvester/sierra/processor/ItemIdUpdateHarvester.java
+++ b/src/main/java/org/nypl/harvester/sierra/processor/ItemIdUpdateHarvester.java
@@ -202,8 +202,8 @@ public class ItemIdUpdateHarvester implements Processor {
             + HarvesterConstants.SIERRA_API_FIELDS_VALUE;
 
     logger.info("Calling api - " + itemApiToCall);
-
-    Exchange templateResultExchange = template.send(itemApiToCall, new Processor() {
+    
+    Exchange templateResultExchange = template.request(itemApiToCall, new Processor() {
       @Override
       public void process(Exchange httpHeaderExchange) throws Exception {
         httpHeaderExchange.getIn().setHeader(Exchange.HTTP_METHOD, HttpMethod.GET);
@@ -211,6 +211,16 @@ public class ItemIdUpdateHarvester implements Processor {
             HarvesterConstants.SIERRA_API_HEADER_AUTHORIZATION_VAL_BEARER + " " + token);
       }
     });
+      
+
+    /*Exchange templateResultExchange = template.send(itemApiToCall, new Processor() {
+      @Override
+      public void process(Exchange httpHeaderExchange) throws Exception {
+        httpHeaderExchange.getIn().setHeader(Exchange.HTTP_METHOD, HttpMethod.GET);
+        httpHeaderExchange.getIn().setHeader(HarvesterConstants.SIERRA_API_HEADER_KEY_AUTHORIZATION,
+            HarvesterConstants.SIERRA_API_HEADER_AUTHORIZATION_VAL_BEARER + " " + token);
+      }
+    });*/
 
     return templateResultExchange;
   }

--- a/src/main/java/org/nypl/harvester/sierra/processor/StreamPoster.java
+++ b/src/main/java/org/nypl/harvester/sierra/processor/StreamPoster.java
@@ -50,25 +50,18 @@ public class StreamPoster implements Processor {
               "?amazonKinesisClient=#getAmazonKinesisClient",
           new Processor() {
             @Override
-            public void process(Exchange kinesisRequest) {
+            public void process(Exchange kinesisRequest) throws SierraHarvesterException {
               try {
-                kinesisRequest.getIn().setHeader(
-                    HarvesterConstants.KINESIS_PARTITION_KEY,
-                    UUID.randomUUID().toString()
-                );
-                kinesisRequest.getIn().setHeader(
-                    HarvesterConstants.KINESIS_SEQUENCE_NUMBER,
-                    System.currentTimeMillis()
-                );
+                kinesisRequest.getIn().setHeader(HarvesterConstants.KINESIS_PARTITION_KEY,
+                    UUID.randomUUID().toString());
+                kinesisRequest.getIn().setHeader(HarvesterConstants.KINESIS_SEQUENCE_NUMBER,
+                    System.currentTimeMillis());
 
-                kinesisRequest.getIn().setBody(
-                    AvroSerializer.encode(
-                        schema,
-                        StreamDataTranslator.translate(getStreamDataModel(), item)
-                    )
-                );
+                kinesisRequest.getIn().setBody(AvroSerializer.encode(schema,
+                    StreamDataTranslator.translate(getStreamDataModel(), item)));
               } catch (Exception exception) {
                 logger.error("Exception thrown encoding data", exception);
+                throw new SierraHarvesterException("Error occurred while posting to stream");
               }
             }
           }

--- a/src/main/java/org/nypl/harvester/sierra/processor/StreamPoster.java
+++ b/src/main/java/org/nypl/harvester/sierra/processor/StreamPoster.java
@@ -28,10 +28,11 @@ public class StreamPoster implements Processor {
   private String streamName;
 
   private StreamDataModel streamDataModel;
-  
+
   private RetryTemplate retryTemplate;
 
-  public StreamPoster(ProducerTemplate template, String streamName, StreamDataModel streamData, RetryTemplate retryTemplate) {
+  public StreamPoster(ProducerTemplate template, String streamName, StreamDataModel streamData,
+      RetryTemplate retryTemplate) {
     this.template = template;
     this.streamName = streamName;
     this.streamDataModel = streamData;
@@ -83,7 +84,7 @@ public class StreamPoster implements Processor {
           return exchange;
         }
       });
-      
+
     }
 
     logger.info("Sent " + items.size() + " items to Kinesis stream: " + getStreamName());

--- a/src/main/java/org/nypl/harvester/sierra/processor/StreamPoster.java
+++ b/src/main/java/org/nypl/harvester/sierra/processor/StreamPoster.java
@@ -45,9 +45,7 @@ public class StreamPoster implements Processor {
 
     for (Item item : items) {
       Exchange exchange = template.send(
-          "aws-kinesis://" +
-              getStreamName() +
-              "?amazonKinesisClient=#getAmazonKinesisClient",
+          "aws-kinesis://" + getStreamName() + "?amazonKinesisClient=#getAmazonKinesisClient",
           new Processor() {
             @Override
             public void process(Exchange kinesisRequest) throws SierraHarvesterException {
@@ -64,15 +62,13 @@ public class StreamPoster implements Processor {
                 throw new SierraHarvesterException("Error occurred while posting to stream");
               }
             }
-          }
-      );
+          });
 
       if (exchange.isFailed()) {
         logger.error("Error processing ProducerTemplate", exchange.getException());
 
         throw new SierraHarvesterException(
-            "Error processing ProducerTemplate: " + exchange.getException().getMessage()
-        );
+            "Error processing ProducerTemplate: " + exchange.getException().getMessage());
       }
     }
 

--- a/src/main/java/org/nypl/harvester/sierra/routebuilder/RouteBuilderIdPoller.java
+++ b/src/main/java/org/nypl/harvester/sierra/routebuilder/RouteBuilderIdPoller.java
@@ -74,9 +74,15 @@ public class RouteBuilderIdPoller extends RouteBuilder {
     }
   }
 
-  public TokenProperties generateNewTokenProperties() {
-    return new OAuth2Client(System.getenv("accessTokenUri"), System.getenv("clientId"),
-        System.getenv("clientSecret"), System.getenv("grantType"))
-            .createAndGetTokenAccessProperties();
+  public TokenProperties generateNewTokenProperties() throws SierraHarvesterException {
+    try {
+      return new OAuth2Client(System.getenv("accessTokenUri"), System.getenv("clientId"),
+          System.getenv("clientSecret"), System.getenv("grantType"))
+              .createAndGetTokenAccessProperties();
+    } catch (Exception e) {
+      logger.error("Error occurred while retrieving sierra token properties - ", e);
+      throw new SierraHarvesterException(
+          "Error occurred while retrieving sierra token properties - " + e.getMessage());
+    }
   }
 }

--- a/src/main/java/org/nypl/harvester/sierra/routebuilder/RouteBuilderIdPoller.java
+++ b/src/main/java/org/nypl/harvester/sierra/routebuilder/RouteBuilderIdPoller.java
@@ -1,6 +1,9 @@
 package org.nypl.harvester.sierra.routebuilder;
 
 import java.util.Date;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.RouteBuilder;
 import org.nypl.harvester.sierra.api.utils.OAuth2Client;
@@ -35,6 +38,14 @@ public class RouteBuilderIdPoller extends RouteBuilder {
 
   @Override
   public void configure() throws Exception {
+    onException(SierraHarvesterException.class).handled(true).process(new Processor() {
+
+      @Override
+      public void process(Exchange exchange) throws Exception {
+        logger.error("FATAL ERROR OCCURRED - Component: sierraitemupdatepoller");
+      }
+    });
+
     from("scheduler:sierrapoller?delay=" + HarvesterConstants.POLL_DELAY + "&useFixedDelay=true")
         // check redis to see if there is updatedDate key
         .process(new CacheItemIdMonitor(retryTemplate))

--- a/src/main/java/org/nypl/harvester/sierra/routebuilder/RouteBuilderIdPoller.java
+++ b/src/main/java/org/nypl/harvester/sierra/routebuilder/RouteBuilderIdPoller.java
@@ -40,14 +40,14 @@ public class RouteBuilderIdPoller extends RouteBuilder {
         .process(new CacheItemIdMonitor(retryTemplate))
         // send the updatedDatekey value to id harvester
         // id harvester has to validate and then query for that until time now
-        .process(new ItemIdUpdateHarvester(getToken(), template))
+        .process(new ItemIdUpdateHarvester(getToken(), template, retryTemplate))
         // send ids to kinesis
         .process(new StreamPoster(template, System.getenv("kinesisItemUpdateStream"),
-            new SierraItemUpdate()))
+            new SierraItemUpdate(), retryTemplate))
         .process(new StreamPoster(template, System.getenv("kinesisItemRetrievalRequestStream"),
-            new SierraItemRetrievalRequest()))
+            new SierraItemRetrievalRequest(), retryTemplate))
         // update Kinesis with last checked time
-        .process(new CacheLastUpdatedTimeUpdater());
+        .process(new CacheLastUpdatedTimeUpdater(retryTemplate));
   }
 
   public String getToken() throws SierraHarvesterException {

--- a/src/main/java/org/nypl/harvester/sierra/routebuilder/RouteBuilderIdPoller.java
+++ b/src/main/java/org/nypl/harvester/sierra/routebuilder/RouteBuilderIdPoller.java
@@ -68,7 +68,7 @@ public class RouteBuilderIdPoller extends RouteBuilder {
 
       if (tokenProperties.getTokenExpiration() == null
           || !currentDate.before(tokenProperties.getTokenExpiration())) {
-        logger.info("Requesting new nypl token");
+        logger.info("Requesting new token");
 
         tokenProperties = generateNewTokenProperties();
         return tokenProperties.getTokenValue();

--- a/src/main/java/org/nypl/harvester/sierra/utils/HarvesterConstants.java
+++ b/src/main/java/org/nypl/harvester/sierra/utils/HarvesterConstants.java
@@ -14,6 +14,8 @@ public class HarvesterConstants {
   public static final String SIERRA_API_RESPONSE_ID = "id";
   public static final String SIERRA_API_RESPONSE_BODY = "body";
   public static final String SIERRA_API_RESPONSE_HTTP_CODE = "sierraResponseCode";
+  public static final String SIERRA_API_HEADER_KEY_AUTHORIZATION = "Authorization";
+  public static final String SIERRA_API_HEADER_AUTHORIZATION_VAL_BEARER = "bearer";
   public static final String KINESIS_PARTITION_KEY = "CamelAwsKinesisPartitionKey";
   public static final String KINESIS_SEQUENCE_NUMBER = "CamelAwsKinesisSequenceNumber";
   public static final String APP_ITEMS_LIST = "items";

--- a/src/test/java/org/nypl/harvester/SierraItemIdPollerAppTests.java
+++ b/src/test/java/org/nypl/harvester/SierraItemIdPollerAppTests.java
@@ -9,8 +9,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 @SpringBootTest
 public class SierraItemIdPollerAppTests {
 
-	@Test
-	public void contextLoads() {
-	}
+  @Test
+  public void contextLoads() {}
 
 }

--- a/src/test/java/org/nypl/harvester/sierra/SierraItemIdPollerAppTests.java
+++ b/src/test/java/org/nypl/harvester/sierra/SierraItemIdPollerAppTests.java
@@ -1,4 +1,4 @@
-package org.nypl.harvester;
+package org.nypl.harvester.sierra;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
 - Removed camel redis and added jedis implementation as it is so easy.
 - added retry capability so when a service is down, the poller will back off and retry after certain time
 - fixed the issue when the total ids are not returned by the sierra api, we continue to poll rather than throw a null pointer exception
- added camel onException and handle the error