### PR TITLE
Adjust `eb create` example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,7 @@ eb create <<environment name>> --instance_type <<size of instance>> \
     --cname <<cname prefix (XXX.us-east-1.elasticbeanstalk.com)>> \
     --vpc.id <<ask for custom vpc_id>> \
     --vpc.ec2subnets <<privateSubnetId1,privateSubnetId2>> \
-    --vpc.elbsubnets <<publicSubnetId1,publicSubnetId2>> \
-    --vpc.elbpublic \
+    --single \
     --profile <<your AWS profile>>
 ```
 


### PR DESCRIPTION
Although this application is deployed to ElasticBeanstalk, it is not a web app.
Since it's not a web app it doesn't need to be public or have an Elastic Load Balancer